### PR TITLE
add .keyword suffix for term query

### DIFF
--- a/elmond/perfsonar-elmond/elmond/filters.py
+++ b/elmond/perfsonar-elmond/elmond/filters.py
@@ -374,8 +374,8 @@ def build_filters(params):
             key = key.replace("-",".")
             #special cases
             key = key.replace("display.set","display-set")
-            key = key.replace("set.source","set-source")
-            key = key.replace("set.dest","set-dest")
+            key = key.replace("set.source","set-source.keyword")
+            key = key.replace("set.dest","set-dest.keyword")
             key = key.replace("psconfig.created.by","psconfig.created-by")
             key = key.replace("psconfig.created-by.user.agent","psconfig.created-by.user-agent")
         elif param.startswith("pscheduler-"):


### PR DESCRIPTION
This fixes #3 . display-set-source and display-set-fields are mapped as text fields so to use them in term query, we need to use the field with the .keyword extension. (for text fields elasticsearch/opensearch automatically creates the keyword field that can be used in term queries)